### PR TITLE
ClockProviderのClockインスタンスを外部Beanとして定義、SpringBootによるDIの際はそちらを取得するように

### DIFF
--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/ClockConfig.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/ClockConfig.java
@@ -1,0 +1,23 @@
+package com.herokuapp.a3181core.punchaclockdev;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// SpringBootが Clock型インスタンス をDIできるようにするためのconfigクラス
+@Configuration
+@RequiredArgsConstructor
+public class ClockConfig {
+
+    private static final ZoneId zoneId = ZoneId.of("Asia/Tokyo");
+
+    // コンポーネントにDIするとき(Autowired, final + RequiredArgsConstructor) これが呼ばれる
+    @Bean
+    public Clock clock() {
+        // TODO bootrunされたときに分かるように明示的に時間を固定しているので、devへマージするときは Clock.now(zoneId) に修正する事
+        return Clock.fixed(Instant.parse("2018-04-29T10:15:30.00Z"), zoneId);
+    }
+}

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProvider.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProvider.java
@@ -1,14 +1,16 @@
 package com.herokuapp.a3181core.punchaclockdev.shared;
 
 import java.time.Clock;
-import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class ClockProvider {
 
-    public Clock now() {
-        return Clock.system(ZoneId.of("Asia/Tokyo"));
-    }
+    private final Clock clock;
 
+    public Clock now() {
+        return clock;
+    }
 }


### PR DESCRIPTION
【このPRはマージしないこと -> 別メンバーの提案コミットを本筋にいれたくないため】
Spring Bean にClockを登録して、ClockProviderのClockインスタンスをDI