### PR TITLE
Slackからの認証かどうかをチェックできるようにした

### DIFF
--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/configure/AppProperties.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/configure/AppProperties.java
@@ -21,6 +21,7 @@ public class AppProperties {
     @Getter
     public static class Slack {
 
+        private final String appSigningSecret;
         private final String appToken;
         private final String channelPostedToId;
     }

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/exception/SlackAuthenticatorUnexpectedException.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/exception/SlackAuthenticatorUnexpectedException.java
@@ -1,0 +1,36 @@
+package com.herokuapp.a3181core.punchaclockdev.exception;
+
+public class SlackAuthenticatorUnexpectedException extends RuntimeException {
+
+    private static final long serialVersionUID = 7656826961398728357L;
+
+    /**
+     * Slack認証予期せぬ例外
+     */
+    public SlackAuthenticatorUnexpectedException() {
+
+    }
+
+    /**
+     * @param message エラーメッセージ
+     */
+    public SlackAuthenticatorUnexpectedException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message エラーメッセージ
+     * @param cause   ネスト例外
+     */
+    public SlackAuthenticatorUnexpectedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * @param cause ネスト例外
+     */
+    public SlackAuthenticatorUnexpectedException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/exception/SlackUnsignedRequestException.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/exception/SlackUnsignedRequestException.java
@@ -1,0 +1,36 @@
+package com.herokuapp.a3181core.punchaclockdev.exception;
+
+public class SlackUnsignedRequestException extends RuntimeException {
+
+    private static final long serialVersionUID = 506827925379999721L;
+
+    /**
+     * Slack未認証リクエスト例外
+     */
+    public SlackUnsignedRequestException() {
+
+    }
+
+    /**
+     * @param message エラーメッセージ
+     */
+    public SlackUnsignedRequestException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message エラーメッセージ
+     * @param cause   ネスト例外
+     */
+    public SlackUnsignedRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * @param cause ネスト例外
+     */
+    public SlackUnsignedRequestException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/AttendController.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/AttendController.java
@@ -31,7 +31,7 @@ public class AttendController {
     public String attend(@RequestParam("name") String name) {
 
         return "Attend, starttime="
-            + clockProvider.getFormatted() + ", name=" + name + ", repository=" + attendService
+            + clockProvider.nowAsFormatted() + ", name=" + name + ", repository=" + attendService
             .parameterBridge(name);
     }
 

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/AttendController.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/AttendController.java
@@ -31,7 +31,7 @@ public class AttendController {
     public String attend(@RequestParam("name") String name) {
 
         return "Attend, starttime="
-            + clockProvider.now() + ", name=" + name + ", repository=" + attendService
+            + clockProvider.getFormatted() + ", name=" + name + ", repository=" + attendService
             .parameterBridge(name);
     }
 

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
@@ -1,7 +1,9 @@
 package com.herokuapp.a3181core.punchaclockdev.presentation;
 
 import com.herokuapp.a3181core.punchaclockdev.domain.model.SlackParam;
+import com.herokuapp.a3181core.punchaclockdev.shared.SlackAuthenticator;
 import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -13,54 +15,78 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class SlackController {
+
+    private final SlackAuthenticator slackAuthenticator;
 
     /**
      * 出勤コメントを返すAPI
      *
      * @param slackParam Slackコマンドから送られるリクエストパラメータ
-     * @param result bindの結果格納
+     * @param result     bindの結果格納
+     * @param request    リクエスト
      * @return 固定値
      */
     @PostMapping(path = "/slack/attend")
-    public String attend(@Validated SlackParam slackParam, BindingResult result) {
+    public String attend(@Validated SlackParam slackParam, BindingResult result,
+        HttpServletRequest request) {
+        validateIfSignedRequestFromSlack(request);
+
         return "出勤！おはようございます\uD83C\uDF1E";
     }
 
     /**
      * 休憩開始コメントを返すAPI
      *
+     * @param request リクエスト
      * @return 固定値
      */
     @RequestMapping(path = "/slack/break", method = RequestMethod.POST)
-    public String breaked() {
+    public String breaked(HttpServletRequest request) {
+        validateIfSignedRequestFromSlack(request);
         return "休憩開始！リラックスしましょう\uD83D\uDE0A";
     }
 
     /**
      * 休憩終了コメントを返すAPI
      *
+     * @param request リクエスト
      * @return 固定値
      */
     @RequestMapping(path = "/slack/return", method = RequestMethod.POST)
-    public String returned() {
+    public String returned(HttpServletRequest request) {
+        validateIfSignedRequestFromSlack(request);
         return "休憩終了！適度に頑張りましょう\uD83C\uDFC3\u200D♂️";
     }
 
     /**
      * 退勤コメントを返すAPI
      *
+     * @param request リクエスト
      * @return 固定値
      */
     @PostMapping(path = "/slack/dismiss")
-    public String dismiss() {
+    public String dismiss(HttpServletRequest request) {
+        validateIfSignedRequestFromSlack(request);
         return "退勤！お疲れさまでした \uD83D\uDECF";
+    }
+
+    void validateIfSignedRequestFromSlack(HttpServletRequest request) {
+        if (slackAuthenticator.isSignedRequestFromSlack(
+            request.getQueryString(),
+            request.getHeader("X-Slack-Request-Timestamp"),
+            request.getHeader("X-Slack-Signature")
+        )) {
+            return;
+        }
+        throw new RuntimeException();
     }
 
     /**
      * リクエストパラメータのbind設定
      *
-     * @param binder リクエストに対するWebDataBinder
+     * @param binder  リクエストに対するWebDataBinder
      * @param request リクエスト時のServletオブジェクト
      */
     @InitBinder("slackParam")

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
@@ -1,6 +1,7 @@
 package com.herokuapp.a3181core.punchaclockdev.presentation;
 
 import com.herokuapp.a3181core.punchaclockdev.domain.model.SlackParam;
+import com.herokuapp.a3181core.punchaclockdev.exception.SlackUnsignedRequestException;
 import com.herokuapp.a3181core.punchaclockdev.shared.SlackAuthenticator;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -80,7 +81,7 @@ public class SlackController {
         )) {
             return;
         }
-        throw new RuntimeException();
+        throw new SlackUnsignedRequestException();
     }
 
     /**

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
@@ -74,11 +74,7 @@ public class SlackController {
     }
 
     void validateIfSignedRequestFromSlack(HttpServletRequest request) {
-        if (slackAuthenticator.isSignedRequestFromSlack(
-            request.getQueryString(),
-            request.getHeader("X-Slack-Request-Timestamp"),
-            request.getHeader("X-Slack-Signature")
-        )) {
+        if (slackAuthenticator.isSignedRequestFromSlack(request)) {
             return;
         }
         throw new SlackUnsignedRequestException();

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
@@ -73,7 +73,7 @@ public class SlackController {
         return "退勤！お疲れさまでした \uD83D\uDECF";
     }
 
-    void validateIfSignedRequestFromSlack(HttpServletRequest request) {
+    private void validateIfSignedRequestFromSlack(HttpServletRequest request) {
         if (slackAuthenticator.isSignedRequestFromSlack(request)) {
             return;
         }

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackExceptionHandler.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.herokuapp.a3181core.punchaclockdev.presentation;
 
+import com.herokuapp.a3181core.punchaclockdev.exception.SlackAuthenticatorUnexpectedException;
 import com.herokuapp.a3181core.punchaclockdev.exception.SlackUnsignedRequestException;
+import com.herokuapp.a3181core.punchaclockdev.shared.ErrorMessageDef;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,8 +20,25 @@ public class SlackExceptionHandler {
      */
 
     @ExceptionHandler({SlackUnsignedRequestException.class})
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public String handleException(SlackUnsignedRequestException ex) {
-        return "失敗！";
+    public ResponseEntity<String> handleException(SlackUnsignedRequestException ex) {
+        return new ResponseEntity<>(
+            ErrorMessageDef.FAILED_TO_POST.getMessage(),
+            ErrorMessageDef.FAILED_TO_POST.getStatus());
     }
+
+    /**
+     * Slack認証予期せぬ例外
+     *
+     * @param ex 例外
+     * @return エラーレスポンス
+     */
+
+    @ExceptionHandler({SlackAuthenticatorUnexpectedException.class})
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<String> handleException(SlackAuthenticatorUnexpectedException ex) {
+        return new ResponseEntity<>(
+            ErrorMessageDef.FAILED_TO_ACCESS.getMessage(),
+            ErrorMessageDef.FAILED_TO_ACCESS.getStatus());
+    }
+
 }

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackExceptionHandler.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.herokuapp.a3181core.punchaclockdev.presentation;
+
+import com.herokuapp.a3181core.punchaclockdev.exception.SlackUnsignedRequestException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class SlackExceptionHandler {
+
+    /**
+     * Slack未認証リクエスト例外
+     *
+     * @param ex 例外
+     * @return エラーレスポンス
+     */
+
+    @ExceptionHandler({SlackUnsignedRequestException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String handleException(SlackUnsignedRequestException ex) {
+        return "失敗！";
+    }
+}

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProvider.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProvider.java
@@ -20,11 +20,20 @@ public class ClockProvider {
     private final Clock clock;
 
     /**
+     * 現在時刻を取得
+     *
+     * @return 現在時刻
+     */
+    public long now() {
+        return clock.instant().getEpochSecond();
+    }
+
+    /**
      * 現在時刻をString型にフォーマット
      *
      * @return フォーマットをかけた現在時刻
      */
-    public String now() {
+    public String getFormatted() {
         return LocalDateTime.now(clock).format(TIME_FORMAT);
     }
 

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProvider.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProvider.java
@@ -24,7 +24,7 @@ public class ClockProvider {
      *
      * @return 現在時刻
      */
-    public long now() {
+    public long nowAsUnixTime() {
         return clock.instant().getEpochSecond();
     }
 
@@ -33,7 +33,7 @@ public class ClockProvider {
      *
      * @return フォーマットをかけた現在時刻
      */
-    public String getFormatted() {
+    public String nowAsFormatted() {
         return LocalDateTime.now(clock).format(TIME_FORMAT);
     }
 

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/ErrorMessageDef.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/ErrorMessageDef.java
@@ -1,0 +1,15 @@
+package com.herokuapp.a3181core.punchaclockdev.shared;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMessageDef {
+    FAILED_TO_POST("投稿に失敗しました。", HttpStatus.BAD_REQUEST),
+    FAILED_TO_ACCESS("サーバーにアクセスできませんでした。", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
@@ -6,6 +6,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -25,15 +26,15 @@ public class SlackAuthenticator {
      * https://api.slack.com/authentication/verifying-requests-from-slack
      * </pre>
      *
-     * @param queryString           リクエストのクエリ文字列
-     * @param slackRequestTimeStamp Slackがリクエストしたときのタイムスタンプ
-     * @param slackSignature        Slackから受け取った署名(期待値)
+     * @param request 検証リクエスト
      * @return Slackからのリクエストの場合 true
      */
     public boolean isSignedRequestFromSlack(
-        String queryString,
-        String slackRequestTimeStamp,
-        String slackSignature) {
+        HttpServletRequest request) {
+
+        String queryString = request.getQueryString();
+        String slackRequestTimeStamp = request.getHeader("X-Slack-Request-Timestamp");
+        String slackSignature = request.getHeader("X-Slack-Signature");
 
         if (isPastForFiveMinutes(slackRequestTimeStamp)) {
             return false;

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
@@ -63,7 +63,7 @@ public class SlackAuthenticator {
         }
         long plusFiveMinutesFromTs = timeStamp + (5 * MINUTE_AS_SECONDS);
 
-        return clockProvider.now() > plusFiveMinutesFromTs;
+        return clockProvider.nowAsUnixTime() > plusFiveMinutesFromTs;
     }
 
     /**

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
@@ -5,6 +5,8 @@ import com.herokuapp.a3181core.punchaclockdev.exception.SlackAuthenticatorUnexpe
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.servlet.http.HttpServletRequest;
@@ -36,7 +38,7 @@ public class SlackAuthenticator {
     public boolean isSignedRequestFromSlack(
         HttpServletRequest request) {
 
-        String queryString = request.getQueryString();
+        String queryString = getRawRequestBodyFromParameter(request);
         String slackRequestTimeStamp = request.getHeader("X-Slack-Request-Timestamp");
         String slackSignature = request.getHeader("X-Slack-Signature");
 
@@ -94,6 +96,13 @@ public class SlackAuthenticator {
             sb.append(String.format("%02x", b & 0xff));
         }
         return sb.toString();
+    }
+
+    private String getRawRequestBodyFromParameter(HttpServletRequest request) {
+        return request.getParameterMap().entrySet().stream()
+            .map(entry -> entry.getKey() + "=" + String
+                .join(",", Arrays.asList(entry.getValue())))
+            .collect(Collectors.joining("&"));
     }
 
     @RequiredArgsConstructor

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
@@ -1,6 +1,7 @@
 package com.herokuapp.a3181core.punchaclockdev.shared;
 
 import com.herokuapp.a3181core.punchaclockdev.configure.AppProperties;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Mac;
@@ -48,6 +49,7 @@ public class SlackAuthenticator {
         // 暗号化ダイジェストを作成
         byte[] digest = new HMacSha256Digest(baseString, secret).digest();
 
+        // 比較
         return slackSignature.equals(generateChallengeToken(digest));
     }
 
@@ -56,7 +58,7 @@ public class SlackAuthenticator {
         try {
             timeStamp = Long.parseLong(slackRequestTimeStamp);
         } catch (NumberFormatException ex) {
-            throw new RuntimeException(ex);
+            return true;
         }
         long plusFiveMinutesFromTs = timeStamp + (5 * MINUTE_AS_SECONDS);
 
@@ -95,8 +97,9 @@ public class SlackAuthenticator {
         byte[] digest() {
             try {
                 Mac mac = Mac.getInstance(SIGNING_CRYPT_ALGORITHM);
-                mac.init(new SecretKeySpec(secret.getBytes(), SIGNING_CRYPT_ALGORITHM));
-                return mac.doFinal(baseString.getBytes());
+                mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+                    SIGNING_CRYPT_ALGORITHM));
+                return mac.doFinal(baseString.getBytes(StandardCharsets.UTF_8));
 
             } catch (InvalidKeyException | NoSuchAlgorithmException ex) {
                 throw new RuntimeException(ex);

--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticator.java
@@ -1,0 +1,89 @@
+package com.herokuapp.a3181core.punchaclockdev.shared;
+
+import com.herokuapp.a3181core.punchaclockdev.configure.AppProperties;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SlackAuthenticator {
+
+    private static final String SLACK_APP_SIGNING_VERSION = "v0";
+
+    private final AppProperties props;
+
+    /**
+     * <pre>
+     * Slackからのリクエストか検証する
+     * https://api.slack.com/authentication/verifying-requests-from-slack
+     * </pre>
+     *
+     * @param queryString           リクエストのクエリ文字列
+     * @param slackRequestTimeStamp Slackがリクエストしたときのタイムスタンプ
+     * @param slackSignature        Slackから受け取った署名(期待値)
+     * @return Slackからのリクエストの場合 true
+     */
+    public boolean isSignedRequestFromSlack(
+        String queryString,
+        String slackRequestTimeStamp,
+        String slackSignature) {
+
+        // Slack認証キーを生成する準備
+        String baseString = String.join(":",
+            SLACK_APP_SIGNING_VERSION,
+            slackRequestTimeStamp,
+            queryString);
+        String secret = props.getSlack().getAppSigningSecret();
+
+        // 暗号化ダイジェストを作成
+        byte[] digest = new HMacSha256Digest(baseString, secret).digest();
+
+        return slackSignature.equals(generateChallengeToken(digest));
+    }
+
+    /**
+     * 暗号化されたダイジェストからSlack認証キーを生成
+     *
+     * @param digest 暗号化されたダイジェスト
+     * @return v0=digestの16進数
+     */
+    private String generateChallengeToken(byte[] digest) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(SLACK_APP_SIGNING_VERSION).append("=");
+
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+
+    @RequiredArgsConstructor
+    private static class HMacSha256Digest {
+
+        private static final String SIGNING_CRYPT_ALGORITHM = "HmacSHA256";
+
+        private final String baseString;
+        private final String secret;
+
+        /**
+         * HMacSha256で暗号化ダイジェストを作成する
+         *
+         * @return HMacSha256で暗号化されたダイジェスト
+         */
+        byte[] digest() {
+            try {
+                Mac mac = Mac.getInstance(SIGNING_CRYPT_ALGORITHM);
+                mac.init(new SecretKeySpec(secret.getBytes(), SIGNING_CRYPT_ALGORITHM));
+                return mac.doFinal(baseString.getBytes());
+
+            } catch (InvalidKeyException | NoSuchAlgorithmException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ server:
 app:
   # SlackAPIとの接続に関する設定
   slack:
+    # SlackApp で発行したSigningSecret
+    app-signing-secret: ${SLACK_APP_SIGNING_SECRET:}
     # SlackAPIで発行したtoken
     app-token: ${SLACK_APP_TOKEN:}
     # 投稿先チャンネルのID

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/AttendControllerTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/AttendControllerTest.java
@@ -66,7 +66,7 @@ class AttendControllerTest {
         //serviceからGoodbye_Worldをcontrollerに入力した想定のテストをしたい(設定しないとnull)
         //mockが機能しているのか、実装の方が動いているのか判断するためにGoodbye_Worldを返させたい
         when(attendService.parameterBridge(anyString())).thenReturn("Goodbye_World");
-        when(clockProvider.now()).thenReturn("2020/04/24 18:24:37");
+        when(clockProvider.getFormatted()).thenReturn("2020/04/24 18:24:37");
 
         //mockmvcからcontrollerにqueryを投げさせる
         this.mockMvc.perform(get(query))

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/AttendControllerTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/AttendControllerTest.java
@@ -66,7 +66,7 @@ class AttendControllerTest {
         //serviceからGoodbye_Worldをcontrollerに入力した想定のテストをしたい(設定しないとnull)
         //mockが機能しているのか、実装の方が動いているのか判断するためにGoodbye_Worldを返させたい
         when(attendService.parameterBridge(anyString())).thenReturn("Goodbye_World");
-        when(clockProvider.getFormatted()).thenReturn("2020/04/24 18:24:37");
+        when(clockProvider.nowAsFormatted()).thenReturn("2020/04/24 18:24:37");
 
         //mockmvcからcontrollerにqueryを投げさせる
         this.mockMvc.perform(get(query))

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackControllerTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackControllerTest.java
@@ -135,7 +135,7 @@ class SlackControllerTest {
 
     @ParameterizedTest
     @MethodSource("slackAuthenticatorExceptionProvider")
-    void errorFromSlackAuthenticator(Throwable clazz) throws Exception {
+    void errorFromSlackAuthenticator(Class<Throwable> clazz) throws Exception {
         when(slackAuthenticator.isSignedRequestFromSlack(any())).thenThrow(clazz);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/slack/attend"))

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackControllerTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackControllerTest.java
@@ -3,6 +3,7 @@ package com.herokuapp.a3181core.punchaclockdev.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.herokuapp.a3181core.punchaclockdev.exception.SlackUnsignedRequestException;
 import com.herokuapp.a3181core.punchaclockdev.shared.SlackAuthenticator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -118,7 +119,7 @@ class SlackControllerTest {
     void errorIfUnsignedSlackRequest() {
         when(slackAuthenticator.isSignedRequestFromSlack(any(), any(), any())).thenReturn(false);
 
-        Assertions.assertThrows(RuntimeException.class,
+        Assertions.assertThrows(SlackUnsignedRequestException.class,
             () -> controller.validateIfSignedRequestFromSlack(new MockHttpServletRequest()));
     }
 }

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackControllerTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackControllerTest.java
@@ -35,7 +35,7 @@ class SlackControllerTest {
 
     @BeforeEach
     void setUp() {
-        when(slackAuthenticator.isSignedRequestFromSlack(any(), any(), any())).thenReturn(true);
+        when(slackAuthenticator.isSignedRequestFromSlack(any())).thenReturn(true);
     }
 
     /**
@@ -117,7 +117,7 @@ class SlackControllerTest {
 
     @Test
     void errorIfUnsignedSlackRequest() {
-        when(slackAuthenticator.isSignedRequestFromSlack(any(), any(), any())).thenReturn(false);
+        when(slackAuthenticator.isSignedRequestFromSlack(any())).thenReturn(false);
 
         Assertions.assertThrows(SlackUnsignedRequestException.class,
             () -> controller.validateIfSignedRequestFromSlack(new MockHttpServletRequest()));

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProviderTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProviderTest.java
@@ -38,7 +38,7 @@ class ClockProviderTest {
     @Test
     void nowTest() {
         long expect = Instant.parse("2018-04-29T10:15:30.00Z").getEpochSecond();
-        assertEquals(expect, fixedClockProvider.now());
+        assertEquals(expect, fixedClockProvider.nowAsUnixTime());
 
     }
 
@@ -47,7 +47,7 @@ class ClockProviderTest {
      */
     @Test
     void timeFormatTest() {
-        assertEquals("2018/04/29 19:15:30", fixedClockProvider.getFormatted());
+        assertEquals("2018/04/29 19:15:30", fixedClockProvider.nowAsFormatted());
 
     }
 }

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProviderTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/ClockProviderTest.java
@@ -30,15 +30,24 @@ class ClockProviderTest {
     @Test
     void timeZoneTest() {
         assertEquals(ZoneId.of("Asia/Tokyo"), clockProvider.getZone());
+    }
+
+    /**
+     * clockProviderのnow()が意図した時刻を返却するかのテスト
+     */
+    @Test
+    void nowTest() {
+        long expect = Instant.parse("2018-04-29T10:15:30.00Z").getEpochSecond();
+        assertEquals(expect, fixedClockProvider.now());
 
     }
 
     /**
-     * clockProviderのnow()がフォーマットされているかのテスト
+     * clockProviderの getFormatted()が 意図したフォーマットをされているかのテスト
      */
     @Test
     void timeFormatTest() {
-        assertEquals("2018/04/29 19:15:30", fixedClockProvider.now());
+        assertEquals("2018/04/29 19:15:30", fixedClockProvider.getFormatted());
 
     }
 }

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
@@ -4,9 +4,13 @@ import static org.mockito.Mockito.when;
 
 import com.herokuapp.a3181core.punchaclockdev.configure.AppProperties;
 import com.herokuapp.a3181core.punchaclockdev.configure.AppProperties.Slack;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,8 +20,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @ExtendWith(MockitoExtension.class)
 class SlackAuthenticatorTest {
 
+    private static final int MINUTE_AS_SECONDS = 60;
+    private static final long BASE_SECONDS = 1000000000L;
+
     @Autowired
     private SlackAuthenticator target;
+
+    @MockBean
+    private ClockProvider clockProvider;
 
     @MockBean
     private AppProperties props;
@@ -33,11 +43,30 @@ class SlackAuthenticatorTest {
 
         Slack slack = new Slack("8f742231b10e8888abcd99yyyzzz85a5", null, null);
         when(props.getSlack()).thenReturn(slack);
+        when(clockProvider.now()).thenReturn(1531420618L);
 
         String queryString = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
         String timeStamp = "1531420618";
         String expect = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
 
         Assertions.assertTrue(target.isSignedRequestFromSlack(queryString, timeStamp, expect));
+    }
+
+    @ParameterizedTest
+    @MethodSource("epochSecondsProvider")
+    void isPastForFiveMinutesPattern(long input, long now, boolean expect) {
+        when(clockProvider.now()).thenReturn(now);
+        Assertions.assertEquals(expect, target.isPastForFiveMinutes(String.valueOf(input)));
+    }
+
+    private static Stream<Arguments> epochSecondsProvider() {
+        long fiveMinutes = (5 * MINUTE_AS_SECONDS);
+        return Stream.of(
+            Arguments.of(BASE_SECONDS, BASE_SECONDS, false),
+            Arguments.of(BASE_SECONDS, BASE_SECONDS + fiveMinutes, false),
+            Arguments.of(BASE_SECONDS, BASE_SECONDS + fiveMinutes - 1, false),
+            Arguments.of(BASE_SECONDS, BASE_SECONDS + fiveMinutes + 1, true)
+
+        );
     }
 }

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
@@ -49,7 +50,12 @@ class SlackAuthenticatorTest {
         String timeStamp = "1531420618";
         String expect = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
 
-        Assertions.assertTrue(target.isSignedRequestFromSlack(queryString, timeStamp, expect));
+        MockHttpServletRequest input = new MockHttpServletRequest();
+        input.setQueryString(queryString);
+        input.addHeader("X-Slack-Request-Timestamp", timeStamp);
+        input.addHeader("X-Slack-Signature", expect);
+
+        Assertions.assertTrue(target.isSignedRequestFromSlack(input));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
@@ -57,10 +57,10 @@ class SlackAuthenticatorTest {
         body.put("channel_name", new String[]{"foobar"});
         body.put("user_id", new String[]{"U2CERLKJA"});
         body.put("user_name", new String[]{"roadrunner"});
-        body.put("command", new String[]{"%2Fwebhook-collect"});
+        body.put("command", new String[]{"/webhook-collect"});
         body.put("text", new String[]{""});
         body.put("response_url", new String[]{
-            "https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN"});
+            "https://hooks.slack.com/commands/T1DC2JH3J/397700885554/96rGlfmibIGlgcZRskXaIFfN"});
         body.put("trigger_id",
             new String[]{"398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"});
 
@@ -96,12 +96,13 @@ class SlackAuthenticatorTest {
         body.put("channel_name", new String[]{"foobar"});
         body.put("user_id", new String[]{"U2CERLKJA"});
         body.put("user_name", new String[]{"roadrunner"});
-        body.put("command", new String[]{"%2Fwebhook-collect"});
+        body.put("command", new String[]{"/webhook-collect"});
         body.put("text", new String[]{""});
         body.put("response_url", new String[]{
-            "https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN"});
+            "https://hooks.slack.com/commands/T1DC2JH3J/397700885554/96rGlfmibIGlgcZRskXaIFfN"});
         body.put("trigger_id",
             new String[]{"398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"});
+
         String timeStamp = "1531420618";
         String expect = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
 
@@ -130,5 +131,30 @@ class SlackAuthenticatorTest {
     void isPastForFiveMinutesPattern(long input, long now, boolean expect) {
         when(clockProvider.nowAsUnixTime()).thenReturn(now);
         Assertions.assertEquals(expect, target.isPastForFiveMinutes(String.valueOf(input)));
+    }
+
+    @Test
+    void isSuccessfullyUrlEncoded() {
+        String expected = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+
+        Map<String, String[]> body = new LinkedHashMap<>();
+        body.put("token", new String[]{"xyzz0WbapA4vBCDEFasx0q6G"});
+        body.put("team_id", new String[]{"T1DC2JH3J"});
+        body.put("team_domain", new String[]{"testteamnow"});
+        body.put("channel_id", new String[]{"G8PSS9T3V"});
+        body.put("channel_name", new String[]{"foobar"});
+        body.put("user_id", new String[]{"U2CERLKJA"});
+        body.put("user_name", new String[]{"roadrunner"});
+        body.put("command", new String[]{"/webhook-collect"});
+        body.put("text", new String[]{""});
+        body.put("response_url", new String[]{
+            "https://hooks.slack.com/commands/T1DC2JH3J/397700885554/96rGlfmibIGlgcZRskXaIFfN"});
+        body.put("trigger_id",
+            new String[]{"398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"});
+
+        MockHttpServletRequest input = new MockHttpServletRequest();
+        input.setParameters(body);
+
+        Assertions.assertEquals(expected, target.getRawRequestBodyFromParameter(input));
     }
 }

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
@@ -44,7 +44,7 @@ class SlackAuthenticatorTest {
 
         Slack slack = new Slack("8f742231b10e8888abcd99yyyzzz85a5", null, null);
         when(props.getSlack()).thenReturn(slack);
-        when(clockProvider.now()).thenReturn(1531420618L);
+        when(clockProvider.nowAsUnixTime()).thenReturn(1531420618L);
 
         String queryString = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
         String timeStamp = "1531420618";
@@ -61,7 +61,7 @@ class SlackAuthenticatorTest {
     @ParameterizedTest
     @MethodSource("epochSecondsProvider")
     void isPastForFiveMinutesPattern(long input, long now, boolean expect) {
-        when(clockProvider.now()).thenReturn(now);
+        when(clockProvider.nowAsUnixTime()).thenReturn(now);
         Assertions.assertEquals(expect, target.isPastForFiveMinutes(String.valueOf(input)));
     }
 

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
@@ -135,7 +135,6 @@ class SlackAuthenticatorTest {
 
     @Test
     void isSuccessfullyUrlEncoded() {
-        String expected = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
 
         Map<String, String[]> body = new LinkedHashMap<>();
         body.put("token", new String[]{"xyzz0WbapA4vBCDEFasx0q6G"});
@@ -154,6 +153,8 @@ class SlackAuthenticatorTest {
 
         MockHttpServletRequest input = new MockHttpServletRequest();
         input.setParameters(body);
+
+        String expected = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
 
         Assertions.assertEquals(expected, target.getRawRequestBodyFromParameter(input));
     }

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
@@ -1,0 +1,43 @@
+package com.herokuapp.a3181core.punchaclockdev.shared;
+
+import static org.mockito.Mockito.when;
+
+import com.herokuapp.a3181core.punchaclockdev.configure.AppProperties;
+import com.herokuapp.a3181core.punchaclockdev.configure.AppProperties.Slack;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+class SlackAuthenticatorTest {
+
+    @Autowired
+    private SlackAuthenticator target;
+
+    @MockBean
+    private AppProperties props;
+
+    @Test
+    void normal() {
+        /*
+         * <pre>
+         * チェック用データはこちらを参考にした
+         * https://api.slack.com/authentication/verifying-requests-from-slack
+         * </pre>
+         */
+
+        Slack slack = new Slack("8f742231b10e8888abcd99yyyzzz85a5", null, null);
+        when(props.getSlack()).thenReturn(slack);
+
+        String queryString = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+        String timeStamp = "1531420618";
+        String expect = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
+
+        Assertions.assertTrue(target.isSignedRequestFromSlack(queryString, timeStamp, expect));
+    }
+}

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/shared/SlackAuthenticatorTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.when;
 import com.herokuapp.a3181core.punchaclockdev.configure.AppProperties;
 import com.herokuapp.a3181core.punchaclockdev.configure.AppProperties.Slack;
 import com.herokuapp.a3181core.punchaclockdev.exception.SlackAuthenticatorUnexpectedException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -47,12 +49,26 @@ class SlackAuthenticatorTest {
         when(props.getSlack()).thenReturn(slack);
         when(clockProvider.nowAsUnixTime()).thenReturn(1531420618L);
 
-        String queryString = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+        Map<String, String[]> body = new LinkedHashMap<>();
+        body.put("token", new String[]{"xyzz0WbapA4vBCDEFasx0q6G"});
+        body.put("team_id", new String[]{"T1DC2JH3J"});
+        body.put("team_domain", new String[]{"testteamnow"});
+        body.put("channel_id", new String[]{"G8PSS9T3V"});
+        body.put("channel_name", new String[]{"foobar"});
+        body.put("user_id", new String[]{"U2CERLKJA"});
+        body.put("user_name", new String[]{"roadrunner"});
+        body.put("command", new String[]{"%2Fwebhook-collect"});
+        body.put("text", new String[]{""});
+        body.put("response_url", new String[]{
+            "https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN"});
+        body.put("trigger_id",
+            new String[]{"398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"});
+
         String timeStamp = "1531420618";
         String expect = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
 
         MockHttpServletRequest input = new MockHttpServletRequest();
-        input.setQueryString(queryString);
+        input.setParameters(body);
         input.addHeader("X-Slack-Request-Timestamp", timeStamp);
         input.addHeader("X-Slack-Signature", expect);
 
@@ -72,12 +88,25 @@ class SlackAuthenticatorTest {
         when(props.getSlack()).thenReturn(slack);
         when(clockProvider.nowAsUnixTime()).thenReturn(1531420618L);
 
-        String queryString = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+        Map<String, String[]> body = new LinkedHashMap<>();
+        body.put("token", new String[]{"xyzz0WbapA4vBCDEFasx0q6G"});
+        body.put("team_id", new String[]{"T1DC2JH3J"});
+        body.put("team_domain", new String[]{"testteamnow"});
+        body.put("channel_id", new String[]{"G8PSS9T3V"});
+        body.put("channel_name", new String[]{"foobar"});
+        body.put("user_id", new String[]{"U2CERLKJA"});
+        body.put("user_name", new String[]{"roadrunner"});
+        body.put("command", new String[]{"%2Fwebhook-collect"});
+        body.put("text", new String[]{""});
+        body.put("response_url", new String[]{
+            "https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN"});
+        body.put("trigger_id",
+            new String[]{"398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"});
         String timeStamp = "1531420618";
         String expect = "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503";
 
         MockHttpServletRequest input = new MockHttpServletRequest();
-        input.setQueryString(queryString);
+        input.setParameters(body);
         input.addHeader("X-Slack-Request-Timestamp", timeStamp);
         input.addHeader("X-Slack-Signature", expect);
 


### PR DESCRIPTION
単体テストにて
・例として挙げられているキーの組み合わせで認証できる

localhost:8080/slack/attend に対して
・環境変数を指定しない場合に、”サーバーにアクセスできませんでした。”が表示される
・パラメータ情報を載せずにリクエストを行い、"投稿に失敗しました。"が表示される

slackアプリから /attendを叩き、
・認証が通る