### PR TITLE
slackからリクエストされたパラメータを Paramクラスを実装して受け取る

### DIFF
--- a/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
+++ b/src/main/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackController.java
@@ -64,11 +64,14 @@ public class SlackController {
     /**
      * 退勤コメントを返すAPI
      *
-     * @param request リクエスト
+     * @param slackParam Slackコマンドから送られるリクエストパラメータ
+     * @param result     bindの結果格納
+     * @param request    リクエスト
      * @return 固定値
      */
     @PostMapping(path = "/slack/dismiss")
-    public String dismiss(HttpServletRequest request) {
+    public String dismiss(@Validated SlackParam slackParam, BindingResult result,
+        HttpServletRequest request) {
         validateIfSignedRequestFromSlack(request);
         return "退勤！お疲れさまでした \uD83D\uDECF";
     }

--- a/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackControllerTest.java
+++ b/src/test/java/com/herokuapp/a3181core/punchaclockdev/presentation/SlackControllerTest.java
@@ -103,9 +103,28 @@ class SlackControllerTest {
             .andExpect(MockMvcResultMatchers.status().isMethodNotAllowed());
     }
 
+    /**
+     * /slack/dismissの正常系テスト
+     * <p>
+     * parameterizedTest化したいときは、paramのvaluesを変数にするとよいです
+     */
     @Test
     void dismissPostTest() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post("/slack/dismiss"))
+        mockMvc.perform(MockMvcRequestBuilders.post("/slack/dismiss")
+            .param("token", "gIkuvaNzQIHg97ATvDxqgjtO")
+            .param("team_id", "T0001")
+            .param("team_domain", "example")
+            .param("enterprise_id", "E0001")
+            .param("enterprise_name", "Globular%20Construct%20Inc")
+            .param("channel_id", "C2147483705")
+            .param("channel_name", "test")
+            .param("user_id", "U2147483697")
+            .param("user_name", "Steve")
+            .param("command", "%2Fweather")
+            .param("text", "94070")
+            .param("response_url", "https%3A%2F%2Fhooks.slack.com%2Fcommands%2F1234%2F5678")
+            .param("trigger_id", "13345224609.738474920 .8088930838d 88f 008e0")
+        )
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.content()
                 .string("退勤！お疲れさまでした \uD83D\uDECF"));


### PR DESCRIPTION
以下チケットの対応を行う
チケット：[/slack/dismiss で、 slackからリクエストされたパラメータを Paramクラスを実装して受け取る](https://trello.com/c/HnHF0Uk5/72-slack-dismiss-%E3%81%A7%E3%80%81-slack%E3%81%8B%E3%82%89%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%81%95%E3%82%8C%E3%81%9F%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF%E3%82%92-param%E3%82%AF%E3%83%A9%E3%82%B9%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%97%E3%81%A6%E5%8F%97%E3%81%91%E5%8F%96%E3%82%8B)